### PR TITLE
Don't crash when pid is invalid

### DIFF
--- a/lib/assert_value/server.ex
+++ b/lib/assert_value/server.ex
@@ -65,7 +65,13 @@ defmodule AssertValue.Server do
   end
 
   def handle_cast({:flush_ex_unit_io}, state) do
-    contents = StringIO.flush(state.captured_ex_unit_io_pid)
+    contents =
+      try do
+        StringIO.flush(state.captured_ex_unit_io_pid)
+      catch
+        :exit, {:noproc, _} -> ""
+      end
+
     if contents != "", do: IO.write(contents)
     {:noreply, state}
   end


### PR DESCRIPTION
Temporary fix for assert-value/assert_value_elixir#14.